### PR TITLE
feat: LocalWebserver plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# pycharm
+.idea
+
+# errbot
+config.py
+errbot.log
+data/
+plugins/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+      language_version: python3
+      types: [python]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    - id: check-ast
+    - id: end-of-file-fixer
+    - id: requirements-txt-fixer
+    - id: debug-statements
+-   repo:  https://github.com/pre-commit/pygrep-hooks
+    rev: v1.6.0
+    hooks:
+    - id: python-no-eval
+    - id: python-no-log-warn
+    - id: python-use-type-annotations
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.3.5
+    hooks:
+    -   id: reorder-python-imports
+-   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+    rev: v1.1.3
+    hooks:
+    -   id: python-safety-dependencies-check
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.6.2
+    hooks:
+    - id: bandit

--- a/LocalWebserver/README.md
+++ b/LocalWebserver/README.md
@@ -1,0 +1,14 @@
+# LocalWebserver
+This plugin is a fork of Errbot's [webserver plugin](https://github.com/errbotio/errbot/blob/master/errbot/core_plugins/webserver.py). 
+
+It was decided to fork and modify the upstream webserver plugin for SaDevbot because of how the upstream configures. For
+a core plugin like the webserver, I want the config to be done outside of bot interactions itself - as env vars. I also
+removed any SSL from the webserver - ssl termination will be handled elsewhere.
+
+# Restrictions
+On Sadevbot, webhooks will not be accessible outside of the bot's container by default. Further config will be required 
+to setup ingress and internet accessibility. 
+
+# Config
+* WEBSERVER_HTTP_HOST: Str, What host to setup the webserver on. Default 127.0.0.1
+* WEBSERVER_HTTP_PORT: Int, What port to setup the webserver on. Default 3142

--- a/LocalWebserver/local-webserver.plug
+++ b/LocalWebserver/local-webserver.plug
@@ -1,0 +1,10 @@
+[Core]
+Name = LocalWebserver
+Module = local-webserver
+Core = True
+
+[Documentation]
+Description = This is a plugin for enabling webhooks and web interface to Errbot ONLY on local host
+
+[Python]
+Version = 3

--- a/LocalWebserver/local-webserver.py
+++ b/LocalWebserver/local-webserver.py
@@ -1,0 +1,104 @@
+from threading import Thread
+
+from webtest import TestApp
+from errbot.core_plugins import flask_app
+from werkzeug.serving import ThreadedWSGIServer
+
+from errbot import botcmd, BotPlugin, webhook
+
+from typing import Dict, Any
+from decouple import config as get_config
+TEST_REPORT = """*** Test Report
+URL : %s
+Detected your post as : %s
+Status code : %i
+"""
+
+
+def get_config_item(
+    key: str, config: Dict, overwrite: bool = False, **decouple_kwargs
+) -> Any:
+    """
+    Checks config to see if key was passed in, if not gets it from the environment/config file
+
+    If key is already in config and overwrite is not true, nothing is done. Otherwise, config var is added to config
+    at key
+    """
+    if key not in config and not overwrite:
+        config[key] = get_config(key, **decouple_kwargs)
+
+
+class Webserver(BotPlugin):
+
+    def __init__(self, *args, **kwargs):
+        self.server = None
+        self.server_thread = None
+        self.ssl_context = None
+        self.test_app = TestApp(flask_app)
+        super().__init__(*args, **kwargs)
+
+    def configure(self, configuration: Dict) -> None:
+        """
+        Configures the plugin
+        """
+        self.log.debug("Starting Config")
+        if configuration is None:
+            configuration = dict()
+
+        # name of the channel to post in
+        get_config_item("WEBSERVER_HTTP_PORT", configuration, default="3142")
+        get_config_item("TOPIC_SCHEDULER_CONFIG", configuration, default={})
+
+        super().configure(configuration)
+
+
+    def activate(self):
+        if not self.config:
+            self.log.info('Webserver is not configured. Forbid activation')
+            return
+
+        if self.server_thread and self.server_thread.is_alive():
+            raise Exception('Invalid state, you should not have a webserver already running.')
+        self.server_thread = Thread(target=self.run_server, name='Webserver Thread')
+        self.server_thread.start()
+        self.log.debug('Webserver started.')
+
+        super().activate()
+
+    def deactivate(self):
+        if self.server is not None:
+            self.log.info('Shutting down the internal webserver.')
+            self.server.shutdown()
+            self.log.info('Waiting for the webserver thread to quit.')
+            self.server_thread.join()
+            self.log.info('Webserver shut down correctly.')
+        super().deactivate()
+
+    def run_server(self):
+        try:
+            host = self.config['WEBSERVER_HTTP_HOST']
+            port = int(self.config['WEBSERVER_HTTP_PORT'])
+            self.log.info('Starting the webserver on %s:%i', host, port)
+            self.server = ThreadedWSGIServer(host, port, flask_app)
+            self.server.serve_forever()
+            self.log.debug('Webserver stopped')
+        except KeyboardInterrupt:
+            self.log.info('Keyboard interrupt, request a global shutdown.')
+            self.server.shutdown()
+        except Exception:
+            self.log.exception('The webserver exploded.')
+
+    @botcmd(template='webstatus')
+    def webstatus(self, msg, args):
+        """
+        Gives a quick status of what is mapped in the internal webserver
+        """
+        return {'rules': (((rule.rule, rule.endpoint) for rule in flask_app.url_map._rules))}
+
+    @webhook
+    def echo(self, incoming_request):
+        """
+        A simple test webhook
+        """
+        self.log.debug("Your incoming request is :" + str(incoming_request))
+        return str(incoming_request)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
This adds a plugin to act as a Webserver for the sadevbot. It replaces
the upstream Errbot core Webserver plugin with our own, slightly
modified implementation.

Also added are some pre-commit hooks for code quality and a few new
gitignore entries. CI is still to come