### PR TITLE
feat: DonationManager and SaDevWebsite

### DIFF
--- a/DonationManager/donation-manager.plug
+++ b/DonationManager/donation-manager.plug
@@ -1,0 +1,10 @@
+[Core]
+Name = DonationManager
+Module = donation-manager
+DependsOn = SADevsWebsite
+
+[Documentation]
+Description = Manages donations for our SA Devs Season of Giving.
+
+[Python]
+Version = 3

--- a/DonationManager/donation-manager.py
+++ b/DonationManager/donation-manager.py
@@ -1,0 +1,426 @@
+import os
+from datetime import datetime
+from hashlib import sha512
+from threading import RLock
+from typing import Any
+from typing import Dict
+from typing import List
+
+from decouple import config as get_config
+from errbot import arg_botcmd
+from errbot import botcmd
+from errbot import BotPlugin
+from errbot.templating import tenv
+from wrapt import synchronized
+
+DONOR_LOCK = RLock()
+RECORDED_LOCK = RLock()
+CONFIRMATION_LOCK = RLock()
+
+
+def get_config_item(
+    key: str, config: Dict, overwrite: bool = False, **decouple_kwargs
+) -> Any:
+    """
+    Checks config to see if key was passed in, if not gets it from the environment/config file
+
+    If key is already in config and overwrite is not true, nothing is done. Otherwise, config var is added to config
+    at key
+    """
+    if key not in config and not overwrite:
+        config[key] = get_config(key, **decouple_kwargs)
+
+
+class DonationManager(BotPlugin):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.website_plugin = None
+
+    def configure(self, configuration: Dict) -> None:
+        """
+        Configures the plugin
+        """
+        self.log.debug("Starting Config")
+        if configuration is None:
+            configuration = dict()
+
+        get_config_item("DONATION_MANAGER_CHANNEL", configuration)
+        configuration["DM_CHANNEL_ID"] = self._bot.channelname_to_channelid(
+            configuration["DONATION_MANAGER_CHANNEL"]
+        )
+        configuration["DM_CHANNEL_IDENTIFIER"] = self.build_identifier(
+            configuration["DONATION_MANAGER_CHANNEL"]
+        )
+        get_config_item("DONATION_MANAGER_REPORT_CHANNEL", configuration)
+        configuration["DM_REPORT_CHANNEL_ID"] = self._bot.channelname_to_channelid(
+            configuration["DONATION_MANAGER_REPORT_CHANNEL"]
+        )
+        configuration["DM_REPORT_CHANNEL_IDENTIFIER"] = self.build_identifier(
+            configuration["DONATION_MANAGER_REPORT_CHANNEL"]
+        )
+        get_config_item(
+            "DM_RECORD_POLLER_INTERVAL", configuration, cast=int, default=3600
+        )
+        super().configure(configuration)
+
+    def activate(self):
+        super().activate()
+        with synchronized(CONFIRMATION_LOCK):
+            try:
+                self["to_be_confirmed"]
+            except KeyError:
+                self["to_be_confirmed"] = dict()
+        with synchronized(RECORDED_LOCK):
+            try:
+                self["to_be_recorded"]
+            except KeyError:
+                self["to_be_recorded"] = dict()
+        with synchronized(DONOR_LOCK):
+            try:
+                self["donations"]
+            except KeyError:
+                self["donations"] = dict()
+        self["donation_total"] = self._total_donations()
+        self.website_plugin = self.get_plugin("SADevsWebsite")
+        self.start_poller(
+            self.config["DM_RECORD_POLLER_INTERVAL"], self._record_donations
+        )
+
+    def deactivate(self):
+        super().deactivate()
+
+    @arg_botcmd("amount", type=str)
+    @arg_botcmd("--make-public", action="store_true", default=False)
+    def donation(self, msg, amount: str, make_public: bool) -> str:
+        """
+        Record a donation for SA Devs Season of Giving
+        """
+
+        if "files" not in msg.extras["slack_event"]:
+            return (
+                "Error: No Receipt.\nPlease attach a PDF receipt of your donation when reporting it using Slack's "
+                "file attachment to your `./donation` message"
+            )
+
+        if "$" not in amount:
+            return (
+                "Error: Please include your amount as a $##.##. i.e. $20.99. You can also use whole numbers like "
+                "$20"
+            )
+
+        amount_float = float(amount.replace("$", ""))
+        if amount_float <= 0:
+            return "Error: Donation amount has to be a positive number."
+
+        file_url = msg.extras["slack_event"]["files"][0]["url_private"]
+        donation_id = sha512(
+            f"{msg.frm}-{amount}-{file_url}".encode("utf-8")
+        ).hexdigest()[-8:]
+
+        try:
+            self._add_donation_for_confirmation(
+                donation_id, amount_float, file_url, msg.frm, make_public
+            )
+        except Exception as err:
+            return f"Error: {err}"
+
+        return_msg = f"Your donation of ${amount_float:.2f} has been reported and is being reviewed."
+        if not make_public:
+            return_msg = (
+                f"{return_msg}\nSince you have elected for your donation to be private, we won't publicize "
+                f"your name."
+            )
+        return_msg = f"{return_msg}\nThank you so very much for your generosity!"
+        return return_msg
+
+    @botcmd(admin_only=True)
+    @arg_botcmd("user", type=str)
+    @arg_botcmd("amount", type=str)
+    @arg_botcmd("--make-public", action="store_true", default=False)
+    def admin_donation(self, msg, amount: str, user: str, make_public: bool) -> str:
+        """
+        As an admin, record a donation for a user that's having issues
+        """
+        if "files" not in msg.extras["slack_event"]:
+            file_url = ""
+        else:
+            file_url = msg.extras["slack_event"]["files"][0]["url_private"]
+
+        if "$" not in amount:
+            return (
+                "Error: Please include your amount as a $##.##. i.e. $20.99. You can also use whole numbers like "
+                "$20"
+            )
+
+        amount_float = float(amount.replace("$", ""))
+        if amount_float <= 0:
+            return "Error: Donation amount has to be a positive number."
+
+        donation_id = sha512(f"{user}-{amount}-{file_url}".encode("utf-8")).hexdigest()[
+            -8:
+        ]
+        user = self.build_identifier(user)
+        try:
+            self._add_donation_for_confirmation(
+                donation_id, amount_float, file_url, user, make_public
+            )
+        except Exception as err:
+            return f"Error: {err}"
+
+        return_msg = f"The donation of ${amount_float:.2f} has been reported and is ready for review."
+        if not make_public:
+            return_msg = (
+                f"{return_msg}\nSince you have elected for this donation to be private, we won't publicize "
+                f"the username."
+            )
+        return return_msg
+
+    @botcmd(admin_only=True)
+    @arg_botcmd("donation_id", type=str)
+    def donation_confirm(self, msg, donation_id: str) -> str:
+        """
+        As an admin, confirm a donation
+        """
+        with synchronized(CONFIRMATION_LOCK):
+            to_be_confirmed = self["to_be_confirmed"]
+            donation = to_be_confirmed.pop(donation_id, None)
+            if donation is None:
+                return f"Error: {donation_id} is not in our donation database."
+            self["to_be_confirmed"] = to_be_confirmed
+
+        with synchronized(RECORDED_LOCK):
+            to_be_recorded = self["to_be_recorded"]
+            to_be_recorded[donation_id] = donation
+            self["to_be_recorded"] = to_be_recorded
+
+        return f"Donation {donation_id} confirmed. Be on the look out for a PR updating the website"
+
+    @botcmd(admin_only=True)
+    @arg_botcmd("amount", type=str)
+    @arg_botcmd("donation_id", type=str)
+    def donation_change(self, msg, donation_id: str, amount: str) -> str:
+        """
+        As an admin, change a donation amount
+        """
+        if "$" not in amount:
+            return (
+                "Error: Please include your amount as a $##.##. i.e. $20.99. You can also use whole numbers like "
+                "$20"
+            )
+
+        amount_float = float(amount.replace("$", ""))
+        if amount_float <= 0:
+            return "Error: Donation amount has to be a positive number."
+
+        with synchronized(CONFIRMATION_LOCK):
+            to_be_confirmed = self["to_be_confirmed"]
+            donation = to_be_confirmed.pop(donation_id, None)
+            if donation is None:
+                return f"Error: {donation_id} is not in our donation database."
+            self["to_be_confirmed"] = to_be_confirmed
+
+        self._add_donation_for_confirmation(
+            donation_id=donation_id,
+            amount=amount_float,
+            file_url=donation["file_url"],
+            user=donation["user"],
+            make_public=donation["user"] is not None,
+        )
+        return (
+            f"Donation {donation_id} has been updated. You can now confirm it with "
+            f"`./donation confirm {donation_id}`"
+        )
+
+    @botcmd(admin_only=True)
+    @arg_botcmd("donation_id", type=str)
+    def donation_delete(self, msg, donation_id: str) -> str:
+        """
+        As an admin, delete a donation either because its spam or needs to be re-submitted
+        """
+        with synchronized(CONFIRMATION_LOCK):
+            try:
+                to_be_confirmed = self["to_be_confirmed"]
+                to_be_confirmed.pop(donation_id)
+                self["to_be_confirmed"] = to_be_confirmed
+                return f"Removed pending donation {donation_id}"
+            except KeyError:
+                pass
+
+        with synchronized(RECORDED_LOCK):
+            try:
+                to_be_recorded = self["to_be_recorded"]
+                to_be_recorded.pop(donation_id)
+                self["to_be_recorded"] = to_be_recorded
+                return f"Removed recorded donation {donation_id}"
+            except KeyError:
+                pass
+
+        with synchronized(DONOR_LOCK):
+            try:
+                donations = self["donations"]
+                donations.pop(donation_id)
+                self["donations"] = donations
+                return (
+                    f"Removed pr'd donation {donation_id}. This won't remove the donation from the page until a pr"
+                    f"is redone with new donations list. You can do this with ./rebuild donations list"
+                )
+            except KeyError:
+                return f"Donation {donation_id} is not found."
+        return f"Donation {donation_id} is not in our donations lists"
+
+    @botcmd(admin_only=True)
+    def list_donations(self, msg, _) -> str:
+        """Lists all the donations we have"""
+
+        yield "*Donations still needing confirmation*:"
+        with synchronized(CONFIRMATION_LOCK):
+            for id, donation in self["to_be_confirmed"].items():
+                yield f"{id}: {donation['user']} - {donation['amount']} - {donation['file_url']}"
+
+        yield "*Donations waiting to be recorded:*"
+        with synchronized(RECORDED_LOCK):
+            yield "\n".join(
+                [
+                    f"{id}: {donation['user']} - {donation['amount']}"
+                    for id, donation in self["to_be_recorded"].items()
+                ]
+            )
+
+        yield "*Confirmed Donations*:"
+        with synchronized(DONOR_LOCK):
+            yield "\n".join(
+                [
+                    f"{id}: {donation['user']} - {donation['amount']}"
+                    for id, donation in self["donations"].items()
+                ]
+            )
+
+    @botcmd(admin_only=True)
+    def rebuild_donations_list(self, msg, *_, **__) -> str:
+        """
+        Rebuilds the websites donations list with the current data
+        """
+        self._record_donations(force=True)
+
+    def _update_blog_post(
+        self, clone_path: str, donations: Dict, donation_total: float
+    ) -> List[str]:
+        """
+        Updates the blog post from our template using the donations dict and total
+        """
+        blog_post = (
+            tenv()
+            .get_template("blog-post.md")
+            .render(total=donation_total, donations=donations)
+        )
+        article_path = os.path.join(
+            clone_path, "content/articles/SADevs-season-of-giving-2020.md"
+        )
+        with open(article_path, "w") as file:
+            file.write(blog_post)
+
+        return [article_path]
+
+    def _add_donation_for_confirmation(
+        self,
+        donation_id: str,
+        amount: float,
+        file_url: str,
+        user: str,
+        make_public: bool,
+    ) -> None:
+        """
+        Adds a donation to be confirmed
+        """
+        if not make_public:
+            user = None
+        else:
+            if type(user) != str:
+                user = self._get_user_real_name(user)
+
+        with synchronized(CONFIRMATION_LOCK):
+            try:
+                to_be_confirmed = self["to_be_confirmed"]
+            except KeyError:
+                to_be_confirmed = dict()
+            if donation_id in to_be_confirmed:
+                raise KeyError(
+                    "Donation is not unique. Did you already add this donation? If this is in error, "
+                    "reach out to the admins"
+                )
+
+            to_be_confirmed[donation_id] = {
+                "amount": amount,
+                "file_url": file_url,
+                "user": user,
+            }
+            self["to_be_confirmed"] = to_be_confirmed
+
+        self.send(
+            self.config["DM_CHANNEL_IDENTIFIER"],
+            text=f"New donation:\n"
+            f"Amount: ${amount:.2f}\n"
+            f"File URL: {file_url}\n"
+            f"User: {user}\n\n"
+            f"To approve this donation run `./donation confirm {donation_id}`\n"
+            f"To change this donation run `./donation change {donation_id} [new amount]`",
+        )
+
+    def _get_user_real_name(self, user) -> str:
+        return self._bot.api_call("users.info", {"user": user.userid})["user"][
+            "profile"
+        ]["real_name"]
+
+    @synchronized(DONOR_LOCK)
+    def _total_donations(self):
+        """Totals donation amounts into self['donation_total']"""
+        total = 0
+        for _, donation in self["donations"].items():
+            total += donation["amount"]
+        return total
+
+    @synchronized(RECORDED_LOCK)
+    def _record_donations(self, force: bool = False) -> None:
+        """
+        Poller that records a donation and turns it into a PR
+        """
+        if len(self["to_be_recorded"].keys()) == 0 and not force:
+            return
+        timestamp = int(datetime.now().timestamp())
+
+        with synchronized(RECORDED_LOCK):
+            to_be_recorded = self["to_be_recorded"]
+            self["to_be_recorded"] = dict()
+
+        with synchronized(DONOR_LOCK):
+            new_donations = {**self["donations"], **to_be_recorded}
+            self["donations"] = new_donations
+
+        self["donation_total"] = self._total_donations()
+        branch_name = f"new-donations-{timestamp}"
+        with self.website_plugin.temp_website_clone(
+            checkout_branch=branch_name
+        ) as website_clone:
+            file_list = self._update_blog_post(
+                website_clone, new_donations, self["donation_total"]
+            )
+            pr = self.website_plugin.open_website_pr(
+                website_clone,
+                file_list,
+                f"updating with new donations {timestamp}",
+                f"Donation Manager: New Donations {timestamp}",
+                "New donations",
+            )
+
+        self.send(
+            self.config["DM_CHANNEL_IDENTIFIER"], text=f"New donation PR:\n" f"{pr}"
+        )
+
+        self.log.debug(self.config["DM_REPORT_CHANNEL_ID"])
+        self._bot.api_call(
+            "conversations.setTopic",
+            {
+                "channel": self.config["DM_REPORT_CHANNEL_ID"],
+                "topic": f"Total Donations in SA Dev's Season of Giving: ${self['donation_total']:.2f}",
+            },
+        )

--- a/DonationManager/requirements.txt
+++ b/DonationManager/requirements.txt
@@ -1,0 +1,2 @@
+python-decouple
+wrapt>=1.12.1

--- a/DonationManager/templates/blog-post.md
+++ b/DonationManager/templates/blog-post.md
@@ -1,0 +1,71 @@
+Title: SA Devs Season of Giving
+Date: 11-01-2020
+Tags: season-of-giving, donations, charity
+Slug: season-of-giving-2020
+Authors: Andrew Herrington 
+Summary: Let's come together as a community to do some good this season!
+
+# SA Devs Season of Giving
+
+## What is Season of Giving
+During the month of November, let's work together as a group to give to those who can use some help. Donate to your 
+favorite charity (we've got some suggestions below), submit your receipt to SA Devs, and we'll amplify your donation. At
+the end of the month, the SA Devs org will match up to $2000 of community donations to the SA Food Bank.
+
+Want to sponsor some matching funds? You can sponsor a day, a week, or the entire month and any amount/total. Reach out
+to the admins and we'll add your matching and notify you of totals!
+
+We also understand some people might want to donate in other ways and we want to celebrate that too! If you donate your 
+time, canned goods, or do any other charitable work and you'd like it celebrated as part of SA Devs Season of Giving,
+reach out to the admins and we'll add it to our donation list! 
+
+### Suggested Charities
+These are charities that we feel are doing good work in our community. Don't feel like you have to donate to these 
+organizations, but if you're looking for a place to donate these are good choices!
+
+Do you have an organization you like to work with? Reach out to the admins and we'll add it to our list!
+
+#### San Antonio Food Bank
+<https://safoodbank.org/>
+
+#### Hill Country Daily Bread
+<https://hillcountrydailybread.com/>
+
+####Get Up Community Center
+<https://www.getupcommunity.org/food-pantry>
+
+
+### How to record a donation
+
+1. Take a screenshot or PDF of your donation receipt
++ Open a DM to `@sadevbot`
++ Send `./donation {amount} --make-public` and attach your receipt to the message 
+If you want to keep your donation private (the admins will still see your name/info but we won't put it on the site) 
+leave out --make-public
+
+Make sure your amount matches the amount on your receipt. You can enter it as $##.## i.e. $20.00 (or even just $20).
+
+Sadevbot will send your donation on to the admins for review and it'll get added to the website (just below here in 
+the donations list). Private donations will just list an amount. The bot will also update totals in 
+`#sadevs-season-of-giving-2020` regularly.
+
+### What to do if you have an issue
+Bot didn't work? Donation didn't show up? Messed up entering a donation? Something else?
+
+DM any of the admins and we can help. We can record your donation manually, delete a donation for you to resubmit, or 
+kick the bot into working again.
+
+## Donation Total And List
+
+Our Donation Total: {{ total }}
+
+### Donations
+
+{% for _, donation in donations.items() -%}
+{% if donation['user'] == None -%}
+{% set user = "Private" -%}
+{% else -%}
+{% set user = donation['user'] -%}
+{% endif -%}
+*  {{ user }} - ${{ "%.2f"|format(donation['amount']) }}
+{% endfor -%}

--- a/SADevsWebsite/README.md
+++ b/SADevsWebsite/README.md
@@ -1,0 +1,14 @@
+# LocalWebserver
+This plugin is a fork of Errbot's [webserver plugin](https://github.com/errbotio/errbot/blob/master/errbot/core_plugins/webserver.py). 
+
+It was decided to fork and modify the upstream webserver plugin for SaDevbot because of how the upstream configures. For
+a core plugin like the webserver, I want the config to be done outside of bot interactions itself - as env vars. I also
+removed any SSL from the webserver - ssl termination will be handled elsewhere.
+
+# Restrictions
+On Sadevbot, webhooks will not be accessible outside of the bot's container by default. Further config will be required 
+to setup ingress and internet accessibility. 
+
+# Config
+* WEBSERVER_HTTP_HOST: Str, What host to setup the webserver on. Default 127.0.0.1
+* WEBSERVER_HTTP_PORT: Int, What port to setup the webserver on. Default 3142

--- a/SADevsWebsite/requirements.txt
+++ b/SADevsWebsite/requirements.txt
@@ -1,0 +1,2 @@
+delegator.py
+python-decouple

--- a/SADevsWebsite/sadevs-website.plug
+++ b/SADevsWebsite/sadevs-website.plug
@@ -1,0 +1,9 @@
+[Core]
+Name = SADevsWebsite
+Module = sadevs-website
+
+[Documentation]
+Description = This plugin lets sadevbot interact with the SA Devs Website
+
+[Python]
+Version = 3

--- a/SADevsWebsite/sadevs-website.py
+++ b/SADevsWebsite/sadevs-website.py
@@ -1,0 +1,137 @@
+import json
+import os
+from contextlib import contextmanager
+from tempfile import TemporaryDirectory
+from typing import Any
+from typing import Dict
+from typing import List
+
+import delegator
+from decouple import config as get_config
+from errbot import BotPlugin
+
+
+class GitError(Exception):
+    pass
+
+
+class GithubError(Exception):
+    pass
+
+
+def get_config_item(
+    key: str, config: Dict, overwrite: bool = False, **decouple_kwargs
+) -> Any:
+    """
+    Checks config to see if key was passed in, if not gets it from the environment/config file
+
+    If key is already in config and overwrite is not true, nothing is done. Otherwise, config var is added to config
+    at key
+    """
+    if key not in config and not overwrite:
+        config[key] = get_config(key, **decouple_kwargs)
+
+
+class SADevsWebsite(BotPlugin):
+    class GitException(Exception):
+        pass
+
+    def configure(self, configuration: Dict) -> None:
+        """
+        Configures the plugin
+        """
+        self.log.debug("Starting Config")
+        if configuration is None:
+            configuration = dict()
+
+        # name of the channel to post in
+        get_config_item(
+            "WEBSITE_GIT_URL",
+            configuration,
+            default="git@github.com:SADevs/sadevs.github.io.git",
+        )
+        get_config_item("WEBSITE_GIT_BASE_BRANCH", configuration, default="website")
+        get_config_item("GITHUB_TOKEN", configuration)
+        super().configure(configuration)
+
+    def activate(self):
+        super().activate()
+
+    def deactivate(self):
+        super().deactivate()
+
+    @contextmanager
+    def temp_website_clone(self, checkout_branch: str = None) -> str:
+        """
+        Contextmanager that offers a temporary clone of the websites gitrepo that can be used to make changes to the
+        site
+        """
+        with TemporaryDirectory() as directory:
+            web_repo_dir = os.path.join(directory, "sadevs-website")
+            clone_result = self._run_git_cmd(
+                directory, f"clone {self.config['WEBSITE_GIT_URL']} sadevs-website"
+            )
+            self.log.debug(clone_result)
+            if checkout_branch is not None:
+                checkout_result = self._run_git_cmd(
+                    web_repo_dir, f"checkout -b {checkout_branch}"
+                )
+                self.log.debug(checkout_result)
+            yield web_repo_dir
+
+    def open_website_pr(
+        self,
+        website_repo_path: str,
+        files_changed: List[str],
+        commit_msg: str,
+        pr_title: str,
+        pr_body: str,
+    ) -> str:
+        """Opens a PR to the website for the changed files. Returns the PR url"""
+        file_list_str = " ".join(files_changed)
+        commit_result = self._run_git_cmd(
+            website_repo_path, f"commit {file_list_str} -m '{commit_msg}'"
+        )
+        self.log.debug(commit_result)
+        push = self._run_git_cmd(website_repo_path, "push origin HEAD")
+        self.log.debug(push)
+        pr_url = self._run_gh_cli_cmd(
+            website_repo_path, f'pr create --title "{pr_title}" --body "{pr_body}"'
+        )
+        return pr_url
+
+    def _run_cmd(
+        self,
+        cmd: str,
+        cwd: str,
+        timeout: int,
+        exception_type: Exception,
+        env: Dict = None,
+    ) -> str:
+        """Runs a command using delegator and returns stdout. Rasies an exception of exception_type if rc != 0"""
+        if env is None:
+            env = dict()
+        env = {**env, **os.environ.copy()}
+        command = delegator.run(cmd, block=True, cwd=cwd, timeout=timeout, env=env)
+
+        self.log.debug("CMD %s run as PID %s", cmd, command.pid)
+        if not command.ok:
+            try:
+                output = command.out()
+            except TypeError:
+                output = ""
+            raise exception_type(json.dumps({"stdout": output, "stderr": command.err}))
+        return command.out
+
+    def _run_git_cmd(self, repo_path: str, cmd: str) -> str:
+        git_result = self._run_cmd(f"git {cmd}", repo_path, 120, GitError)
+        return git_result
+
+    def _get_gh_user(self) -> str:
+        """Auths to the GH api with the PAT. Used to get the current username + validate our GH token works"""
+        api_response = self._run_gh_cli_cmd("/tmp", "api user")
+        return json.loads(api_response)["login"]
+
+    def _run_gh_cli_cmd(self, repo_path: str, cmd: str) -> str:
+        gh_result = self._run_cmd(f"gh {cmd}", repo_path, 120, GithubError)
+        return gh_result


### PR DESCRIPTION
This is a two for one PR. Two new plugins!

SADevsWebsite: This plugin provides helper methods to manage the SA Devs
Website. Right now, it offers a context manager to get you a temporary
clone of the website's repo and a way to do a PR to the website.
Changing files is an exercise left up to the other plugin writer.

DonationManager is for SA Devs Season of Giving. It gives members a way
to record a donation with its ./donation command and gives admin tools
to manage the lifecycle of a submitted donation. Admins can approve,
change, and delete donations. Approved donations are pr'd to the
website in groups once every hour by a poller and a slack channel topic
is updated with our new donation total.