### PR TITLE
ci: make CI install plugin deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
     - name: Install Dependencies
       run: |
         python3 -m pip install -r test-requirements.txt
+    - name: Install Plugin Dependencies
+      run: |
+        bash ci/install_plugin_deps.sh
     - name: Unit tests
       run: |
         coverage run -m pytest .

--- a/ci/install_plugin_deps.sh
+++ b/ci/install_plugin_deps.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+for file in $(find . -name "requirements.txt"); do
+  python3 -m pip install -r $file
+done


### PR DESCRIPTION
errbot in testmode does not auto install plugin dependencies. 

This script find all requirements.txt files and pip installs them